### PR TITLE
docs: clarify cloud_provider_cluster input description

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Parses the cloud provider tuple format used throughout KoalaOps workflows.
 
 | Input | Description | Required |
 |-------|-------------|----------|
-| `cloud_provider_cluster` | Cloud tuple in format: provider/account/location/cluster | ✅ |
+| `cloud_provider_cluster` | The cloud provider, account/project, location and cluster name, in format: provider/account/location/cluster | ✅ |
 
 ## Outputs
 


### PR DESCRIPTION
## Summary
- Improved the `cloud_provider_cluster` input description in README for better clarity
- Explicitly mentions all components: cloud provider, account/project, location, and cluster name

## Changes
- Updated README.md input table description to be more descriptive

## Test plan
- Documentation change only, no functional changes